### PR TITLE
Update useClickOutside.ts

### DIFF
--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -2,17 +2,23 @@ import { MutableRefObject, useEffect } from 'react';
 
 const useClickOutside = (
   ref: MutableRefObject<HTMLElement | null>,
-  handler: (event: Event) => void
+  handler: (event: MouseEvent) => void
 ) => {
   useEffect(() => {
-    const callback = (event: Event) => {
-      const el = ref.current;
-      if (!event || !el || el.contains((event as any).target)) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const element = ref.current;
+
+      if (!element || element.contains(target)) return;
+
       handler(event);
     };
 
-    document.addEventListener('click', callback);
-    return () => document.removeEventListener('click', callback);
+    document.addEventListener('click', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
   }, [ref, handler]);
 };
 


### PR DESCRIPTION
**Changes made:**

1. Changed the type of the handler function parameter to` (event: MouseEvent) => void instead of (event: Event) => void`, which provides better type safety for mouse events.

2. Renamed the callback variable to `handleClickOutside `for clarity.
 
3. Replaced `(event as any).target` with `event.target as Node` to improve type safety.
 
4. Moved the element assignment outside the if condition to avoid checking !element multiple times.
 
5. Simplified the condition in the `if `statement.